### PR TITLE
Manage features extraction when volume is very low

### DIFF
--- a/dreamo_video_structure/class_audioProcessor.pde
+++ b/dreamo_video_structure/class_audioProcessor.pde
@@ -7,7 +7,7 @@ class AudioProcessor implements AudioListener
   private float[] mix;
   private float[] silence;
 
-
+  private float SILENCE_THRESHOLD;
 
   private float frameEnergy;
 
@@ -37,6 +37,7 @@ class AudioProcessor implements AudioListener
     right = null;
 
     silence = new float[bSize];
+    SILENCE_THRESHOLD = 10e-5;
 
     frameEnergy=0;
 
@@ -133,7 +134,7 @@ class AudioProcessor implements AudioListener
 
     mix(); //check if is to slow
 
-    if (frameEnergy < 10e-5) {
+    if (frameEnergy < SILENCE_THRESHOLD) {
       mix = silence.clone();
     }
 

--- a/dreamo_video_structure/class_audioProcessor.pde
+++ b/dreamo_video_structure/class_audioProcessor.pde
@@ -5,6 +5,9 @@ class AudioProcessor implements AudioListener
   private float[] left;
   private float[] right;
   private float[] mix;
+  private float[] silence;
+
+
 
   private float frameEnergy;
 
@@ -32,6 +35,8 @@ class AudioProcessor implements AudioListener
   {
     left = null;
     right = null;
+
+    silence = new float[bSize];
 
     frameEnergy=0;
 
@@ -128,8 +133,12 @@ class AudioProcessor implements AudioListener
 
     mix(); //check if is to slow
 
-    //calculate fourier transform
-    calcFFT(mix);
+    if (frameEnergy > 10e-5) {
+      //calculate fourier transform
+      calcFFT(mix);
+    } else {
+      calcFFT(silence);
+    }
 
     calcRMS(mix);
 
@@ -222,6 +231,7 @@ class AudioProcessor implements AudioListener
       energy += FastMath.pow(left[i], 2) + FastMath.pow(right[i], 2);
     }
     frameEnergy = (float) energy;
+    //println("frame energy: " + frameEnergy);
   }
 
   private void mix()

--- a/dreamo_video_structure/class_audioProcessor.pde
+++ b/dreamo_video_structure/class_audioProcessor.pde
@@ -133,12 +133,12 @@ class AudioProcessor implements AudioListener
 
     mix(); //check if is to slow
 
-    if (frameEnergy > 10e-5) {
-      //calculate fourier transform
-      calcFFT(mix);
-    } else {
-      calcFFT(silence);
+    if (frameEnergy < 10e-5) {
+      mix = silence.clone();
     }
+
+    //calculate fourier transform
+    calcFFT(mix);
 
     calcRMS(mix);
 


### PR DESCRIPTION
When volume is very low timbre features such as spectral centroid and complexity or COBE give wrong calculation results (the input is basically ground noise).

This PR sets a threshold that is compared to **frameEnergy**. If the energy is lower, all samples are forced to 0 (silence).

All operation are performed in **AudioProcessor** class.

Parameter **SILENCE_THRESHOLD** is now set to **10e-5** but should be tweaked after live tests.

Fix for #13.